### PR TITLE
Add Command and RobotMap configuration ability

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -11,7 +11,7 @@
 			<attribute name="javadoc_location" value="jar:platform:/resource/2017-2706-Robot-Code/lib/non-robot-libs/google/docs.zip!/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="var" path="USERLIBS_DIR/CTRLib.jar"/>
 	<classpathentry kind="var" path="USERLIBS_DIR/navx_frc.jar"/>
+	<classpathentry kind="var" path="USERLIBS_DIR/CTRLib.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,28 @@ Subsystems classes are for the lowest end things like gyro, direct communication
 
 ### Commands
 
+__Command Format:__
+
+Commands that have `String` or primitive type parameters in their constructors that benefit from being able to read parameters from a file stored on the robot should include `String name` as the final parameter in the constructor. The first line of the constructor body should be a call to the parent constructor passing the name as the command name. Any values that should be loaded from the config file should use `RobotConfig.get(name + ".[variable name]", defaultValue)` to set the value, for example:
+
+```Java
+public MyCommand(String var1, int var2, boolean var3, String name) {
+    this.var1 = RobotConfig.get(name + ".var1", var1);
+    this.var2 = RobotConfig.get(name + ".var2", var2);
+    this.var3 = RobotConfig.get(name + ".var3", var3);
+}
+```
+
+When choosing a name for a command, make sure to use something that identifies what the specific instance of the command does and that the name is unique. (Unless the name is at a different level like `"CommandGroup1.DriveForward"` and `"DriveForward"` will both work.
+
+For CommandGroups follow the same rules as before, for example:
+
+```Java
+public MyCommandGroup(boolean var1, String name) {
+    this.addSequential(new MyCommand("Test", 44, var1, name + ".testCommand");
+}
+```
+
 The Commands folder / package is split into two types of commands:
 
 __Autonomous Commands:__

--- a/src/org/usfirst/frc/team2706/robot/OI.java
+++ b/src/org/usfirst/frc/team2706/robot/OI.java
@@ -49,7 +49,7 @@ public class OI {
 
         // Stop driving and go into brake mode, stopping the robot
         TriggerButtonJoystick driverBackLeftTrigger = new TriggerButtonJoystick(driverStick, 2);
-        driverBackLeftTrigger.runWhileHeld(new HandBrake(true));
+        driverBackLeftTrigger.runWhileHeld(new HandBrake(true, "DriverHandbrake"));
 
      //   // Stop the robot by going into brake mode
        // TriggerButtonJoystick driverBackRightTrigger = new TriggerButtonJoystick(driverStick, 3);

--- a/src/org/usfirst/frc/team2706/robot/Robot.java
+++ b/src/org/usfirst/frc/team2706/robot/Robot.java
@@ -68,7 +68,7 @@ public class Robot extends IterativeRobot {
         hardwareChooser = new AutonomousSelector(
                          /* no switch: do nothing */ new ArcadeDriveWithJoystick(),
                         /* position 1: do nothing */ new ArcadeDriveWithJoystick(),
-             /* position 2: Move Forward one foot */ new StraightDriveWithEncoders(0.4, 1, 1, 1)
+             /* position 2: Move Forward one foot */ new StraightDriveWithEncoders(0.4, 1, 1, 1, "AutoForwardFoot")
         );
 
         // Set up the Microsoft LifeCam and start streaming it to the Driver Station
@@ -77,7 +77,7 @@ public class Robot extends IterativeRobot {
         UsbCamera rearCamera = CameraServer.getInstance().startAutomaticCapture(1);
         
         recordAJoystick = new RecordJoystick(oi.getDriverJoystick(), oi.getOperatorJoystick(),
-                        () -> SmartDashboard.getString("record-joystick-name", "default"));        
+                        () -> SmartDashboard.getString("record-joystick-name", "default"), "recordJoystick");        
     }
 
     /**
@@ -134,7 +134,7 @@ public class Robot extends IterativeRobot {
             recordAJoystick.start();
 
         // Tell drive team to drive
-        rumbler = new StickRumble(0.4, 0.15, 1, 0, 1, 1.0, 1);
+        rumbler = new StickRumble(0.4, 0.15, 1, 0, 1, 1.0, 1, "controllerStickRumble");
         rumbler.start();
         
         // Deactivate the camera ring light

--- a/src/org/usfirst/frc/team2706/robot/RobotConfig.java
+++ b/src/org/usfirst/frc/team2706/robot/RobotConfig.java
@@ -1,7 +1,21 @@
 package org.usfirst.frc.team2706.robot;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Optional;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
 public class RobotConfig {
 
+    private static final File CONFIG_FOLDER = new File("/home/lvuser/config/");
+    
     /**
      * Gets a configuration value from the robot filesystem
      * 
@@ -9,8 +23,152 @@ public class RobotConfig {
      * @param defaultValue The value to be returned if no other value exists
      * @return The value for of the property
      */
-    // Currently unused
-    public static <T> T get(String name, T defaultValue) {
-        return defaultValue;
+    public static boolean get(String name, boolean defaultValue) {
+        Optional<JsonPrimitive> val = get(name, new JsonPrimitive(defaultValue));
+        if(val.isPresent()) {
+            return val.get().getAsBoolean();
+        }
+        else {
+            return defaultValue;
+        }
+    }
+    
+    /**
+     * Gets a configuration value from the robot filesystem
+     * 
+     * @param name The name of the property to get
+     * @param defaultValue The value to be returned if no other value exists
+     * @return The value for of the property
+     */
+    public static char get(String name, char defaultValue) {
+        Optional<JsonPrimitive> val = get(name, new JsonPrimitive(defaultValue));
+        if(val.isPresent()) {
+            return val.get().getAsCharacter();
+        }
+        else {
+            return defaultValue;
+        }
+    }
+    
+    /**
+     * Gets a configuration value from the robot filesystem
+     * 
+     * @param name The name of the property to get
+     * @param defaultValue The value to be returned if no other value exists
+     * @return The value for of the property
+     */
+    public static Number get(String name, Number defaultValue) {
+        Optional<JsonPrimitive> val = get(name, new JsonPrimitive(defaultValue));
+        if(val.isPresent()) {
+            return val.get().getAsNumber();
+        }
+        else {
+            return defaultValue;
+        }
+    }
+    
+    /**
+     * Gets a configuration value from the robot filesystem
+     * 
+     * @param name The name of the property to get
+     * @param defaultValue The value to be returned if no other value exists
+     * @return The value for of the property
+     */
+    public static String get(String name, String defaultValue) {
+        Optional<JsonPrimitive> val = get(name, new JsonPrimitive(defaultValue));
+        if(val.isPresent()) {
+            return val.get().getAsString();
+        }
+        else {
+            return defaultValue;
+        }
+    }
+    
+    private static Optional<JsonPrimitive> get(String name, JsonPrimitive defaultValue) {
+        String[] path = name.split(".");
+        if(path.length < 2) {
+            return Optional.empty();
+        }
+        
+        JsonObject json;
+        JsonObject root;        
+        Optional<JsonObject> optional = getJSON(path[0]);
+        if(optional.isPresent()) {
+            json = optional.get();
+            root = json;
+        }
+        else {
+            return Optional.empty();
+        }
+
+        boolean success = true;
+        
+        for(int i = 1; i < path.length - 2; i++) {
+            if(!json.has(path[i])) {
+                json.addProperty(path[i], "");
+                success = false;
+            }
+            json = json.getAsJsonObject(path[i]);
+        }
+        
+        if(!json.has(path[path.length - 1])) {
+            json.add(path[path.length - 1], defaultValue);
+            
+            success = false;
+        }
+        else {
+            return Optional.of(json.getAsJsonPrimitive(path[path.length - 1]));
+        }
+        
+        if(!success) {
+            reserialize(path[0], root);
+        }
+        
+        return Optional.empty();
+        
+    }
+    
+    private static Optional<JsonObject> getJSON(String name) {
+        File configFile = new File(CONFIG_FOLDER, name + ".json");
+        
+        StringBuilder src = new StringBuilder();
+        try {
+            if(!configFile.isFile()) {
+                configFile.createNewFile();
+                return Optional.empty();
+            }
+            
+            BufferedReader configReader = new BufferedReader(new FileReader(configFile));
+            
+            String line;
+            while((line = configReader.readLine()) != null) {
+                // JSON doesn't care about newlines
+                src.append(line); 
+            }
+            
+            configReader.close();
+        }
+        catch(IOException e) {
+            return Optional.empty();
+        }
+        
+        return Optional.of(
+                   new Gson().fromJson(src.toString(), JsonObject.class));
+    }
+    
+    private static void reserialize(String name, JsonObject object) {
+        String output = new GsonBuilder().setPrettyPrinting().create().toJson(object);
+        
+        File configFile = new File(CONFIG_FOLDER, name + ".json");
+        
+        try {
+            FileWriter writer = new FileWriter(configFile);
+            writer.write(output);
+            writer.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        
+        
     }
 }

--- a/src/org/usfirst/frc/team2706/robot/RobotConfig.java
+++ b/src/org/usfirst/frc/team2706/robot/RobotConfig.java
@@ -18,7 +18,7 @@ import com.google.gson.JsonPrimitive;
  * @author eandr127
  */
 public class RobotConfig {
-    
+
     /**
      * Gets a configuration value from the robot filesystem
      * 
@@ -29,76 +29,73 @@ public class RobotConfig {
     @SuppressWarnings("unchecked")
     public static <T> T get(String name, T defaultValue) {
         // Create JSON primitives depending on the type of T
-        if(defaultValue instanceof Boolean) {
+        if (defaultValue instanceof Boolean) {
             // Try to get the value of the config location or return Optional.empty() for default
-            Optional<JsonPrimitive> val = get(name, new JsonPrimitive(Boolean.class.cast(defaultValue)));
-            if(val.isPresent()) {
+            Optional<JsonPrimitive> val =
+                            get(name, new JsonPrimitive(Boolean.class.cast(defaultValue)));
+            if (val.isPresent()) {
                 // Cast the returned value back to to T to be returned
                 return (T) defaultValue.getClass().cast(val.get().getAsBoolean());
             }
-        }
-        else if(defaultValue instanceof String) {
+        } else if (defaultValue instanceof String) {
             // Try to get the value of the config location or return Optional.empty() for default
-            Optional<JsonPrimitive> val = get(name, new JsonPrimitive(String.class.cast(defaultValue)));
-            if(val.isPresent()) {
+            Optional<JsonPrimitive> val =
+                            get(name, new JsonPrimitive(String.class.cast(defaultValue)));
+            if (val.isPresent()) {
                 // Cast the returned value back to to T to be returned
                 return (T) defaultValue.getClass().cast(val.get().getAsString());
             }
-        }
-        else if(defaultValue instanceof Character) {
+        } else if (defaultValue instanceof Character) {
             // Try to get the value of the config location or return Optional.empty() for default
-            Optional<JsonPrimitive> val = get(name, new JsonPrimitive(Character.class.cast(defaultValue)));
-            if(val.isPresent()) {
+            Optional<JsonPrimitive> val =
+                            get(name, new JsonPrimitive(Character.class.cast(defaultValue)));
+            if (val.isPresent()) {
                 // Cast the returned value back to to T to be returned
                 return (T) defaultValue.getClass().cast(val.get().getAsCharacter());
             }
-        }
-        else if(defaultValue instanceof Number) {
+        } else if (defaultValue instanceof Number) {
             // Try to get the value of the config location or return Optional.empty() for default
-            Optional<JsonPrimitive> val = get(name, new JsonPrimitive(Number.class.cast(defaultValue)));
-            if(val.isPresent()) {
+            Optional<JsonPrimitive> val =
+                            get(name, new JsonPrimitive(Number.class.cast(defaultValue)));
+            if (val.isPresent()) {
                 // Cast the number back to the correct type it should be
                 Number num = val.get().getAsNumber();
-                if(defaultValue instanceof Byte) {
+                if (defaultValue instanceof Byte) {
                     return (T) defaultValue.getClass().cast(num.byteValue());
-                }
-                else if(defaultValue instanceof Double) {
+                } else if (defaultValue instanceof Double) {
                     return (T) defaultValue.getClass().cast(num.doubleValue());
-                }
-                else if(defaultValue instanceof Float) {
+                } else if (defaultValue instanceof Float) {
                     return (T) defaultValue.getClass().cast(num.floatValue());
-                }
-                else if(defaultValue instanceof Integer) {
+                } else if (defaultValue instanceof Integer) {
                     return (T) defaultValue.getClass().cast(num.intValue());
-                }
-                else if(defaultValue instanceof Long) {
+                } else if (defaultValue instanceof Long) {
                     return (T) defaultValue.getClass().cast(num.longValue());
-                }
-                else if(defaultValue instanceof Short) {
+                } else if (defaultValue instanceof Short) {
                     return (T) defaultValue.getClass().cast(num.shortValue());
                 }
             }
         }
-        
-        // Either config didn't have correct information, T wasn't a valid type, or value wasn't overridden
+
+        // Either config didn't have correct information, T wasn't a valid type, or value wasn't
+        // overridden
         return defaultValue;
-    } 
-    
+    }
+
     /**
      * Location of the folder that config files are stored
      */
     private static final File CONFIG_FOLDER = new File("/home/lvuser/config/");
-    
+
     /**
      * The name of the primitives for override and value
      */
     private static final String OVERRIDE = "override", VALUE = "value";
-    
+
     /**
      * Different JSON types
      */
     private static final int TYPE_BOOLEAN = 0, TYPE_NUMBER = 1, TYPE_STRING = 2;
-    
+
     /**
      * Get's a JSON primitive from a location or return default value
      * 
@@ -109,85 +106,82 @@ public class RobotConfig {
     private static Optional<JsonPrimitive> get(String name, JsonPrimitive defaultValue) {
         // Get each name in the chain of objects
         String[] path = name.split("\\.");
-        
+
         // Ensure path has a file name, and a name within the file
-        if(path.length < 2) {
+        if (path.length < 2) {
             return Optional.empty();
         }
-        
+
         JsonObject json;
         JsonObject root;
-        
+
         // Try to load the file from the filesystem, otherwise make empty object t
         Optional<JsonObject> optional = getJSON(path[0]);
-        if(optional.isPresent()) {
+        if (optional.isPresent()) {
             json = optional.get();
-        }
-        else {
+        } else {
             json = new JsonObject();
         }
-        
+
         // Save root for reserialization
         root = json;
 
         // Assume every value required can be loaded successfully until they're not
         boolean reserialize = true;
-        
+
         // Go through each sub object starting after the file name
-        for(int i = 1; i < path.length; i++) {
+        for (int i = 1; i < path.length; i++) {
             // Ensure that the name exists and is an object that can have children
-            if(!json.has(path[i]) || !json.get(path[i]).isJsonObject()) {
+            if (!json.has(path[i]) || !json.get(path[i]).isJsonObject()) {
                 // Remake the missing object and indicate that reserialization is necessary
                 json.remove(path[i]);
                 json.add(path[i], new JsonObject());
                 reserialize = false;
             }
-            
+
             // Move to child so that loop will get closer to the final name in the path
             json = json.getAsJsonObject(path[i]);
         }
-        
-        // Ensure that value and override are valid, otherwise they must both be made before reserialization
-        if(!json.has(VALUE) || !json.get(VALUE).isJsonPrimitive()
-                        || getPrimitiveType(json.get(VALUE).getAsJsonPrimitive())
-                        != getPrimitiveType(defaultValue)
+
+        // Ensure that value and override are valid, otherwise they must both be made before
+        // reserialization
+        if (!json.has(VALUE) || !json.get(VALUE).isJsonPrimitive() || getPrimitiveType(
+                        json.get(VALUE).getAsJsonPrimitive()) != getPrimitiveType(defaultValue)
                         || !json.has(OVERRIDE) || !json.get(OVERRIDE).isJsonPrimitive()) {
             reserialize = false;
         }
         // Value is not overriden
-        else if(!json.get(OVERRIDE).getAsBoolean()) {
-            
+        else if (!json.get(OVERRIDE).getAsBoolean()) {
+
             // Indicate that the override and value must be remade
-            if(!json.get(VALUE).getAsJsonPrimitive().equals(defaultValue)) {
+            if (!json.get(VALUE).getAsJsonPrimitive().equals(defaultValue)) {
                 reserialize = false;
-            }
-            else {
+            } else {
                 // No changes are required, and cofnig indicated default value
                 return Optional.empty();
             }
         }
-        
+
         // JSON must be rewritten
-        if(!reserialize) {
+        if (!reserialize) {
             // Remake override and value tags as default
             json.remove(OVERRIDE);
             json.addProperty(OVERRIDE, false);
-            
+
             json.remove(VALUE);
             json.add(VALUE, defaultValue);
-            
+
             // Rewrite file
             reserialize(path[0], root);
-            
+
             // Use default value
             return Optional.empty();
-        }
-        else {
+        } else {
             // Config indicates that its value should be used, so use it
             return Optional.of(json.getAsJsonPrimitive("value"));
         }
     }
-    
+
     /**
      * Gets the type of a {@code JsonPrimitive}
      * 
@@ -195,17 +189,15 @@ public class RobotConfig {
      * @return The type
      */
     private static int getPrimitiveType(JsonPrimitive primitive) {
-        if(primitive.isBoolean()) {
+        if (primitive.isBoolean()) {
             return TYPE_BOOLEAN;
-        }
-        else if(primitive.isNumber()) {
+        } else if (primitive.isNumber()) {
             return TYPE_NUMBER;
-        }
-        else {
+        } else {
             return TYPE_STRING;
         }
     }
-    
+
     /**
      * Loads JSON from a file name (without file extension)
      * 
@@ -215,40 +207,38 @@ public class RobotConfig {
     private static Optional<JsonObject> getJSON(String name) {
         // Get the file location
         File configFile = new File(CONFIG_FOLDER, name + ".json");
-        
+
         StringBuilder src = new StringBuilder();
         try {
-            
+
             // Create file as it doesn't exist
-            if(!configFile.isFile()) {
+            if (!configFile.isFile()) {
                 configFile.getParentFile().mkdirs();
                 configFile.createNewFile();
-                
+
                 // Continue to create JSON for file and write it back to the file
                 return Optional.empty();
             }
-            
+
             BufferedReader configReader = new BufferedReader(new FileReader(configFile));
-            
+
             // Read each line into a String
             String line;
-            while((line = configReader.readLine()) != null) {
+            while ((line = configReader.readLine()) != null) {
                 // JSON doesn't care about newlines
-                src.append(line); 
+                src.append(line);
             }
-            
+
             configReader.close();
-        }
-        catch(IOException e) {
+        } catch (IOException e) {
             // Something went wrong, just use default value
             return Optional.empty();
         }
-        
+
         // Create the root JSON object from the JSON text
-        return Optional.of(
-                   new Gson().fromJson(src.toString(), JsonObject.class));
+        return Optional.of(new Gson().fromJson(src.toString(), JsonObject.class));
     }
-    
+
     /**
      * Rewrite the JSON file
      * 
@@ -258,10 +248,10 @@ public class RobotConfig {
     private static void reserialize(String name, JsonObject object) {
         // Create JSON String with nice formatting
         String output = new GsonBuilder().setPrettyPrinting().create().toJson(object);
-        
+
         // Find file to write to
         File configFile = new File(CONFIG_FOLDER, name + ".json");
-        
+
         // Write the JSON data to the file
         try {
             FileWriter writer = new FileWriter(configFile);

--- a/src/org/usfirst/frc/team2706/robot/RobotConfig.java
+++ b/src/org/usfirst/frc/team2706/robot/RobotConfig.java
@@ -12,11 +12,12 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
+/**
+ * Handles loading of data required for autonomous modes and {@link RobotMap}
+ * 
+ * @author eandr127
+ */
 public class RobotConfig {
-
-    private static final File CONFIG_FOLDER = new File("/home/lvuser/config/");
-    private static final String OVERRIDE = "override", VALUE = "value";
-    private static final int TYPE_BOOLEAN = 0, TYPE_NUMBER = 1, TYPE_STRING = 2;
     
     /**
      * Gets a configuration value from the robot filesystem
@@ -27,27 +28,36 @@ public class RobotConfig {
      */
     @SuppressWarnings("unchecked")
     public static <T> T get(String name, T defaultValue) {
+        // Create JSON primitives depending on the type of T
         if(defaultValue instanceof Boolean) {
+            // Try to get the value of the config location or return Optional.empty() for default
             Optional<JsonPrimitive> val = get(name, new JsonPrimitive(Boolean.class.cast(defaultValue)));
             if(val.isPresent()) {
+                // Cast the returned value back to to T to be returned
                 return (T) defaultValue.getClass().cast(val.get().getAsBoolean());
             }
         }
         else if(defaultValue instanceof String) {
+            // Try to get the value of the config location or return Optional.empty() for default
             Optional<JsonPrimitive> val = get(name, new JsonPrimitive(String.class.cast(defaultValue)));
             if(val.isPresent()) {
+                // Cast the returned value back to to T to be returned
                 return (T) defaultValue.getClass().cast(val.get().getAsString());
             }
         }
         else if(defaultValue instanceof Character) {
+            // Try to get the value of the config location or return Optional.empty() for default
             Optional<JsonPrimitive> val = get(name, new JsonPrimitive(Character.class.cast(defaultValue)));
             if(val.isPresent()) {
+                // Cast the returned value back to to T to be returned
                 return (T) defaultValue.getClass().cast(val.get().getAsCharacter());
             }
         }
         else if(defaultValue instanceof Number) {
+            // Try to get the value of the config location or return Optional.empty() for default
             Optional<JsonPrimitive> val = get(name, new JsonPrimitive(Number.class.cast(defaultValue)));
             if(val.isPresent()) {
+                // Cast the number back to the correct type it should be
                 Number num = val.get().getAsNumber();
                 if(defaultValue instanceof Byte) {
                     return (T) defaultValue.getClass().cast(num.byteValue());
@@ -70,17 +80,45 @@ public class RobotConfig {
             }
         }
         
+        // Either config didn't have correct information, T wasn't a valid type, or value wasn't overridden
         return defaultValue;
     } 
     
+    /**
+     * Location of the folder that config files are stored
+     */
+    private static final File CONFIG_FOLDER = new File("/home/lvuser/config/");
+    
+    /**
+     * The name of the primitives for override and value
+     */
+    private static final String OVERRIDE = "override", VALUE = "value";
+    
+    /**
+     * Different JSON types
+     */
+    private static final int TYPE_BOOLEAN = 0, TYPE_NUMBER = 1, TYPE_STRING = 2;
+    
+    /**
+     * Get's a JSON primitive from a location or return default value
+     * 
+     * @param name The name of the property to find
+     * @param defaultValue The default value in case the name can't be found
+     * @return The JSON primitive value of the property if it can be found
+     */
     private static Optional<JsonPrimitive> get(String name, JsonPrimitive defaultValue) {
+        // Get each name in the chain of objects
         String[] path = name.split("\\.");
+        
+        // Ensure path has a file name, and a name within the file
         if(path.length < 2) {
             return Optional.empty();
         }
         
         JsonObject json;
-        JsonObject root;        
+        JsonObject root;
+        
+        // Try to load the file from the filesystem, otherwise make empty object t
         Optional<JsonObject> optional = getJSON(path[0]);
         if(optional.isPresent()) {
             json = optional.get();
@@ -89,52 +127,73 @@ public class RobotConfig {
             json = new JsonObject();
         }
         
+        // Save root for reserialization
         root = json;
 
-        boolean success = true;
+        // Assume every value required can be loaded successfully until they're not
+        boolean reserialize = true;
         
+        // Go through each sub object starting after the file name
         for(int i = 1; i < path.length; i++) {
+            // Ensure that the name exists and is an object that can have children
             if(!json.has(path[i]) || !json.get(path[i]).isJsonObject()) {
+                // Remake the missing object and indicate that reserialization is necessary
                 json.remove(path[i]);
                 json.add(path[i], new JsonObject());
-                success = false;
+                reserialize = false;
             }
+            
+            // Move to child so that loop will get closer to the final name in the path
             json = json.getAsJsonObject(path[i]);
         }
         
+        // Ensure that value and override are valid, otherwise they must both be made before reserialization
         if(!json.has(VALUE) || !json.get(VALUE).isJsonPrimitive()
                         || getPrimitiveType(json.get(VALUE).getAsJsonPrimitive())
-                        != getPrimitiveType(defaultValue)) {
-            success = false;
+                        != getPrimitiveType(defaultValue)
+                        || !json.has(OVERRIDE) || !json.get(OVERRIDE).isJsonPrimitive()) {
+            reserialize = false;
         }
-        
-        if(!json.has(OVERRIDE) || !json.get(OVERRIDE).isJsonPrimitive()) {
-            success = false;
-        }
+        // Value is not overriden
         else if(!json.get(OVERRIDE).getAsBoolean()) {
+            
+            // Indicate that the override and value must be remade
             if(!json.get(VALUE).getAsJsonPrimitive().equals(defaultValue)) {
-                success = false;
+                reserialize = false;
             }
             else {
+                // No changes are required, and cofnig indicated default value
                 return Optional.empty();
             }
         }
         
-        if(!success) {
+        // JSON must be rewritten
+        if(!reserialize) {
+            // Remake override and value tags as default
             json.remove(OVERRIDE);
             json.addProperty(OVERRIDE, false);
             
             json.remove(VALUE);
             json.add(VALUE, defaultValue);
             
+            // Rewrite file
             reserialize(path[0], root);
+            
+            // Use default value
             return Optional.empty();
         }
         else {
+            // Config indicates that its value should be used, so use it
             return Optional.of(json.getAsJsonPrimitive("value"));
         }
     }
     
+    /**
+     * Gets the type of a {@code JsonPrimitive}
+     * 
+     * @param primitive The primitive to check
+     * @return The type
+     */
     private static int getPrimitiveType(JsonPrimitive primitive) {
         if(primitive.isBoolean()) {
             return TYPE_BOOLEAN;
@@ -147,19 +206,31 @@ public class RobotConfig {
         }
     }
     
+    /**
+     * Loads JSON from a file name (without file extension)
+     * 
+     * @param name The name of the file
+     * @return The Root tag of the JSON file if it can be loaded
+     */
     private static Optional<JsonObject> getJSON(String name) {
+        // Get the file location
         File configFile = new File(CONFIG_FOLDER, name + ".json");
         
         StringBuilder src = new StringBuilder();
         try {
+            
+            // Create file as it doesn't exist
             if(!configFile.isFile()) {
                 configFile.getParentFile().mkdirs();
                 configFile.createNewFile();
+                
+                // Continue to create JSON for file and write it back to the file
                 return Optional.empty();
             }
             
             BufferedReader configReader = new BufferedReader(new FileReader(configFile));
             
+            // Read each line into a String
             String line;
             while((line = configReader.readLine()) != null) {
                 // JSON doesn't care about newlines
@@ -169,18 +240,29 @@ public class RobotConfig {
             configReader.close();
         }
         catch(IOException e) {
+            // Something went wrong, just use default value
             return Optional.empty();
         }
         
+        // Create the root JSON object from the JSON text
         return Optional.of(
                    new Gson().fromJson(src.toString(), JsonObject.class));
     }
     
+    /**
+     * Rewrite the JSON file
+     * 
+     * @param name The name of the file name without its file extension
+     * @param object The root JSON to reserialize
+     */
     private static void reserialize(String name, JsonObject object) {
+        // Create JSON String with nice formatting
         String output = new GsonBuilder().setPrettyPrinting().create().toJson(object);
         
+        // Find file to write to
         File configFile = new File(CONFIG_FOLDER, name + ".json");
         
+        // Write the JSON data to the file
         try {
             FileWriter writer = new FileWriter(configFile);
             writer.write(output);
@@ -188,7 +270,5 @@ public class RobotConfig {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        
-        
     }
 }

--- a/src/org/usfirst/frc/team2706/robot/RobotConfig.java
+++ b/src/org/usfirst/frc/team2706/robot/RobotConfig.java
@@ -1,0 +1,16 @@
+package org.usfirst.frc.team2706.robot;
+
+public class RobotConfig {
+
+    /**
+     * Gets a configuration value from the robot filesystem
+     * 
+     * @param name The name of the property to get
+     * @param defaultValue The value to be returned if no other value exists
+     * @return The value for of the property
+     */
+    // Currently unused
+    public static <T> T get(String name, T defaultValue) {
+        return defaultValue;
+    }
+}

--- a/src/org/usfirst/frc/team2706/robot/RobotMap.java
+++ b/src/org/usfirst/frc/team2706/robot/RobotMap.java
@@ -183,8 +183,8 @@ public class RobotMap {
     @SuppressWarnings("unchecked")
     private static <T> T getConstant(String constant) {
         try {
-            return (T) getArray(RobotMap.class.getDeclaredField(constant + "_VALS")
-                            .get(null))[ROBOT_ID];
+            return RobotConfig.get("RobotMap." + constant, (T) getArray(RobotMap.class.getDeclaredField(constant + "_VALS")
+                            .get(null))[ROBOT_ID]);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/core/RotateDriveWithGyro.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/core/RotateDriveWithGyro.java
@@ -2,6 +2,7 @@ package org.usfirst.frc.team2706.robot.commands.autonomous.core;
 
 import org.usfirst.frc.team2706.robot.Log;
 import org.usfirst.frc.team2706.robot.Robot;
+import org.usfirst.frc.team2706.robot.RobotConfig;
 
 import edu.wpi.first.wpilibj.PIDController;
 import edu.wpi.first.wpilibj.command.Command;
@@ -30,15 +31,17 @@ public class RotateDriveWithGyro extends Command {
      * 
      * @param speed Speed in range [-1,1]
      * @param angle The angle to rotate to
+     * @param name The name of the of the configuration properties to look for
      */
-    public RotateDriveWithGyro(double speed, double angle, int minDonecycles) {
+    public RotateDriveWithGyro(double speed, double angle, int minDonecycles, String name) {
+        super(name);
         requires(Robot.driveTrain);
 
-        this.speed = speed;
+        this.speed = RobotConfig.get(name + ".speed", speed);
 
-        this.angle = angle;
+        this.angle = RobotConfig.get(name + ".angle", angle);
 
-        this.minDoneCycles = minDonecycles;
+        this.minDoneCycles = RobotConfig.get(name + ".minDoneCycles", minDonecycles);
 
         PID = new PIDController(P, I, D, F, Robot.driveTrain.getGyroPIDSource(false),
                         Robot.driveTrain.getDrivePIDOutput(false, false, true));

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/core/StraightDriveWithEncoders.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/core/StraightDriveWithEncoders.java
@@ -2,6 +2,7 @@ package org.usfirst.frc.team2706.robot.commands.autonomous.core;
 
 import org.usfirst.frc.team2706.robot.Log;
 import org.usfirst.frc.team2706.robot.Robot;
+import org.usfirst.frc.team2706.robot.RobotConfig;
 
 import edu.wpi.first.wpilibj.PIDController;
 import edu.wpi.first.wpilibj.command.Command;
@@ -29,18 +30,20 @@ public class StraightDriveWithEncoders extends Command {
      * @param speed Speed in range [-1,1]
      * @param distance The encoder distance to travel
      * @param error The range that the robot is happy ending the command in
+     * @param name The name of the of the configuration properties to look for
      */
     public StraightDriveWithEncoders(double speed, double distance, double error,
-                    int minDoneCycles) {
+                    int minDoneCycles, String name) {
+        super(name);
         requires(Robot.driveTrain);
 
-        this.speed = speed;
+        this.speed = RobotConfig.get(name + ".speed", speed);
 
-        this.distance = distance;
+        this.distance = RobotConfig.get(name + ".distance", distance);
 
-        this.error = error / 12.0;
+        this.error = RobotConfig.get(name + ".error", error) / 12;
 
-        this.minDoneCycles = minDoneCycles;
+        this.minDoneCycles = RobotConfig.get(name + ".minDoneCycles", minDoneCycles);
 
         PID = new PIDController(P, I, D, F, Robot.driveTrain.getAverageEncoderPIDSource(),
                         Robot.driveTrain.getDrivePIDOutput(true, false, false));

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/core/StraightDriveWithTime.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/core/StraightDriveWithTime.java
@@ -4,6 +4,8 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import org.usfirst.frc.team2706.robot.Robot;
+import org.usfirst.frc.team2706.robot.RobotConfig;
+
 import edu.wpi.first.wpilibj.command.Command;
 
 /**
@@ -20,14 +22,15 @@ public class StraightDriveWithTime extends Command {
      * 
      * @param speed Speed in range [-1,1]
      * @param time Time in milliseconds to drive
+     * @param name The name of the of the configuration properties to look for
      */
-    public StraightDriveWithTime(double speed, long time) {
-        super("StraightDriveWithTime");
+    public StraightDriveWithTime(double speed, long time, String name) {
+        super(name);
         requires(Robot.driveTrain);
 
-        this.speed = -speed;
+        this.speed = -RobotConfig.get(name + ".speed", speed);
 
-        this.time = time;
+        this.time = RobotConfig.get(name + ".time", time);
     }
 
     // Called just before this Command runs the first time

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/experimential/curvedrive/CurveDrive.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/experimential/curvedrive/CurveDrive.java
@@ -1,6 +1,7 @@
 package org.usfirst.frc.team2706.robot.commands.autonomous.experimential.curvedrive;
 
 import org.usfirst.frc.team2706.robot.Robot;
+import org.usfirst.frc.team2706.robot.RobotConfig;
 
 import edu.wpi.first.wpilibj.command.Command;
 
@@ -35,15 +36,17 @@ public class CurveDrive extends Command {
      * @param yFeet Distance forward, in feet (preferably not negative)
      * @param endCurve Ending angle (-90 to 90 degrees, but only useful at -80 to 80)
      * @param speed Base speed the robot drives (-1.0 to 1.0)
+     * @param name The name of the of the configuration properties to look for
      */
-    public CurveDrive(double xFeet, double yFeet, double endCurve, double speed, boolean isRight) {
+    public CurveDrive(double xFeet, double yFeet, double endCurve, double speed, boolean isRight, String name) {
+        super(name);
         requires(Robot.driveTrain);
 
-        this.xFeet = xFeet;
-        this.yFeet = yFeet;
-        this.endCurve = endCurve;
-        this.speed = speed;
-        this.isRight = isRight;
+        this.xFeet = RobotConfig.get(name + ".xFeet", xFeet);
+        this.yFeet = RobotConfig.get(name + ".yFeet", yFeet);
+        this.endCurve = RobotConfig.get(name + ".endCurve", endCurve);
+        this.speed = RobotConfig.get(name + ".speed", speed);
+        this.isRight = RobotConfig.get(name + ".isRight", isRight);
     }
 
     protected void initialize() {

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/experimential/curvedrive/CurveDrive.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/experimential/curvedrive/CurveDrive.java
@@ -125,6 +125,7 @@ public class CurveDrive extends Command {
         // Finds out what x position you should be at, and compares it with what you are currently at
         double wantedX = (eq.a * Math.pow(yPos, 3)) + (eq.b * Math.pow(xPos, 2));
 
+        @SuppressWarnings("unused")
         double offset = xPos - wantedX;
 
         // Figures out how far you should rotate based on offset and gyro pos

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/experimential/movements/QuickRotate.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/experimential/movements/QuickRotate.java
@@ -2,6 +2,7 @@ package org.usfirst.frc.team2706.robot.commands.autonomous.experimential.movemen
 
 import org.usfirst.frc.team2706.robot.Log;
 import org.usfirst.frc.team2706.robot.Robot;
+import org.usfirst.frc.team2706.robot.RobotConfig;
 
 import edu.wpi.first.wpilibj.command.Command;
 
@@ -38,13 +39,14 @@ public class QuickRotate extends Command {
      * Rotates by the specified angle
      * 
      * @param targetHeading The angle the robot will rotate to (-360 to 360)
+     * @param name The name of the of the configuration properties to look for
      */
-    public QuickRotate(double targetHeading) {
-        super("QuickRotate");
+    public QuickRotate(double targetHeading, String name) {
+        super(name);
 
         requires(Robot.driveTrain);
 
-        this.targetHeading = normalize(targetHeading);
+        this.targetHeading = RobotConfig.get(name + ".targetHeading", normalize(targetHeading));
     }
 
     // Called just before this Command runs the first time

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/experimential/recordreplay/RecordJoystick.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/experimential/recordreplay/RecordJoystick.java
@@ -5,6 +5,7 @@ import java.util.function.Supplier;
 import org.usfirst.frc.team2706.robot.Log;
 import org.usfirst.frc.team2706.robot.OI;
 import org.usfirst.frc.team2706.robot.Robot;
+import org.usfirst.frc.team2706.robot.RobotConfig;
 import org.usfirst.frc.team2706.robot.commands.teleop.ArcadeDriveWithJoystick;
 
 import edu.wpi.first.wpilibj.Joystick;
@@ -26,8 +27,8 @@ public class RecordJoystick extends Command {
      * 
      * @see #RecordJoystick(Joystick, Joystick, Supplier) The main constructor
      */
-    public RecordJoystick(Joystick driverStick, Joystick operatorStick, String name) {
-        this(driverStick, operatorStick, () -> name);
+    public RecordJoystick(Joystick driverStick, Joystick operatorStick, String joystickName, String name) {
+        this(driverStick, operatorStick, () -> RobotConfig.get(name + ".joystickName", joystickName), name);
     }
 
     /**
@@ -37,9 +38,12 @@ public class RecordJoystick extends Command {
      * @param operatorStick The operator Joystick to record
      * @param nameSupplier The Supplier that is used to find file locations when the command is
      *        enabled
+     * @param name The name of the of the configuration properties to look for
      */
     public RecordJoystick(Joystick driverStick, Joystick operatorStick,
-                    Supplier<String> nameSupplier) {
+                    Supplier<String> nameSupplier, String name) {
+        super(name);
+        
         this.nameSupplier = nameSupplier;
 
         this.driverStick = driverStick;

--- a/src/org/usfirst/frc/team2706/robot/commands/autonomous/experimential/recordreplay/ReplayRecordedJoystick.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/autonomous/experimential/recordreplay/ReplayRecordedJoystick.java
@@ -5,6 +5,7 @@ import java.util.function.Supplier;
 import org.usfirst.frc.team2706.robot.Log;
 import org.usfirst.frc.team2706.robot.OI;
 import org.usfirst.frc.team2706.robot.Robot;
+import org.usfirst.frc.team2706.robot.RobotConfig;
 import org.usfirst.frc.team2706.robot.commands.teleop.ArcadeDriveWithJoystick;
 
 import edu.wpi.first.wpilibj.Joystick;
@@ -28,8 +29,8 @@ public class ReplayRecordedJoystick extends Command {
      * @see #ReplayRecordableJoystick(Joystick, Joystick, Supplier) The main constructor
      */
     public ReplayRecordedJoystick(Joystick driverStick, Joystick operatorStick, String name,
-                    boolean deserializeInConstructor) {
-        this(driverStick, operatorStick, () -> name, deserializeInConstructor);
+                    boolean deserializeInConstructor, String joystickName) {
+        this(driverStick, operatorStick, () -> RobotConfig.get(name + ".joystickName", joystickName), deserializeInConstructor, name);
     }
 
     /**
@@ -43,9 +44,12 @@ public class ReplayRecordedJoystick extends Command {
      * @param deserializeInConstructor When true, does not wait until the command is enabled to find
      *        the location of the files, this is important for competitions where delays in the
      *        start of autonomous are a bigger issue
+     * @param name The name of the of the configuration properties to look for
      */
     public ReplayRecordedJoystick(Joystick driverStick, Joystick operatorStick,
-                    Supplier<String> nameSupplier, boolean deserializeInConstructor) {
+                    Supplier<String> nameSupplier, boolean deserializeInConstructor, String name) {
+        super(name);
+        
         this.nameSupplier = nameSupplier;
 
         this.driverStick = driverStick;
@@ -54,11 +58,11 @@ public class ReplayRecordedJoystick extends Command {
         this.deserializeInConstructor = deserializeInConstructor;
 
         if (deserializeInConstructor) {
-            String name = nameSupplier.get();
+            String joystickName = nameSupplier.get();
             String folder = "/home/lvuser/joystick-recordings/" + name + "/";
 
-            String driverLoc = folder + name + "-driver";
-            String operatorLoc = folder + name + "-operator";
+            String driverLoc = folder + joystickName + "-driver";
+            String operatorLoc = folder + joystickName + "-operator";
 
             this.driverStick = new RecordableJoystick(driverStick, driverLoc, true);
             this.operatorStick = new RecordableJoystick(operatorStick, operatorLoc, true);

--- a/src/org/usfirst/frc/team2706/robot/commands/teleop/HandBrake.java
+++ b/src/org/usfirst/frc/team2706/robot/commands/teleop/HandBrake.java
@@ -1,6 +1,7 @@
 package org.usfirst.frc.team2706.robot.commands.teleop;
 
 import org.usfirst.frc.team2706.robot.Robot;
+import org.usfirst.frc.team2706.robot.RobotConfig;
 
 import edu.wpi.first.wpilibj.command.Command;
 
@@ -13,9 +14,12 @@ public class HandBrake extends Command {
      * Puts robot into brake mode and can disable driving if wanted
      * 
      * @param stopDriving Whether to disable driving
+     * @param name The name of the of the configuration properties to look for
      */
-    public HandBrake(boolean stopDriving) {
-        if (stopDriving)
+    public HandBrake(boolean stopDriving, String name) {
+        super(name);
+        
+        if (RobotConfig.get(name + ".stopDriving", stopDriving))
             requires(Robot.driveTrain);
     }
 

--- a/src/org/usfirst/frc/team2706/robot/controls/StickRumble.java
+++ b/src/org/usfirst/frc/team2706/robot/controls/StickRumble.java
@@ -1,6 +1,7 @@
 package org.usfirst.frc.team2706.robot.controls;
 
 import org.usfirst.frc.team2706.robot.Robot;
+import org.usfirst.frc.team2706.robot.RobotConfig;
 
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 import edu.wpi.first.wpilibj.Joystick;
@@ -63,24 +64,27 @@ public class StickRumble extends Command {
      * @param intensity How much the controllers will vibrate.
      * @param whichController Select which controller will vibrate. <p>
      * 0 = both, 1 = driver, 2 = operator.
+     * @param name The name of the of the configuration properties to look for
      */
     public StickRumble(double timeOn, double timeOff, int repeatCount, double intervalTime,
-                    int intervalCount, double intensity, int whichController) {
+                    int intervalCount, double intensity, int whichController, String name) {
+        super(name);
+        
         joystick = Robot.oi.getDriverJoystick();
         operatorJoy = Robot.oi.getOperatorJoystick();
         finished = false;
 
         // Need to know this to get time passed.
-        this.timeOn = timeOn;
-        this.timeOff = timeOff;
-        this.repeatCount = repeatCount;
-        StickRumble.repeatCountCopy = repeatCount;
-        StickRumble.intervalTime = intervalTime;
-        StickRumble.intervalCount = intervalCount;
+        this.timeOn = RobotConfig.get(name + ".timeOn", timeOn);
+        this.timeOff = RobotConfig.get(name + ".timeOff", timeOff);
+        this.repeatCount = RobotConfig.get(name + ".repeatCount", repeatCount);
+        StickRumble.repeatCountCopy = RobotConfig.get(name + ".repeatCount", repeatCount);
+        StickRumble.intervalTime = RobotConfig.get(name + ".intervalTime", intervalTime);
+        StickRumble.intervalCount = RobotConfig.get(name + ".intervalCount", intervalCount);
         if (StickRumble.intervalCount == -1)
             infiniteCount = true;
-        vibrationIntensity = intensity;
-        selectionOfController = whichController;
+        vibrationIntensity = RobotConfig.get(name + ".intensity", intensity);
+        selectionOfController = RobotConfig.get(name + ".whichController", whichController);
         finished = false;
     }
     

--- a/src/org/usfirst/frc/team2706/robot/subsystems/Camera.java
+++ b/src/org/usfirst/frc/team2706/robot/subsystems/Camera.java
@@ -3,7 +3,6 @@ package org.usfirst.frc.team2706.robot.subsystems;
 import java.util.ArrayList;
 
 import org.usfirst.frc.team2706.robot.Log;
-import org.usfirst.frc.team2706.robot.Robot;
 import org.usfirst.frc.team2706.robot.RobotMap;
 import org.usfirst.frc.team2706.robot.subsystems.TrackerBox2.TargetObject;
 


### PR DESCRIPTION
Using `RobotConfig.get(String name, T defaultValue)` allows the caller to get any `String` or primitive to load from a JSON file. The value is located by splitting the name by periods. The location of a given JSON in the directory `/home/lvusr/config/`, and the filename is the first section of the name ended with `".json"`. Any other tags are sub JSON objects. The final object contains `"value"` and `"override"` tags. The value element holds the `JsonPrimitive` value of the property, and the override element is whether or not the value should actually be used. This was done so that non-overridden values can be reset to the values in the code when they are left unchanged. All invalid config files are regenerated from where they became broken, or if there was no file in the first place.

There are a number of problems with this solution
1. The solution makes use of templates. These are useful for things like `RobotMap` that don't know the type of the value that is going to be used, and reduces the amount of code needed to be written. This solution is somewhat messy because GSON (the JSON parser) can't handle templates, and each parameter must be cast to work with a valid GSON method, and cast back before being returned.
2. It requires extra work in commands to get them working by requiring a name for each command. This is a bit annoying, but makes understanding what each command does a bit easier.
3. Instances of a command that inadvertently have the same name could overwrite each others' values.

`RobotConfig` has been tested on my computer, but never on the actual robot. To avoid causing people to change all of their commands to integrate with `RobotConfig` in the future, this pull request should probably be merged as soon as it has been tested and reviewed adequately.