### PR TITLE
Intake: Adjust intake RPM to force cube rotation

### DIFF
--- a/src/org/usfirst/frc/team2706/robot/subsystems/Intake.java
+++ b/src/org/usfirst/frc/team2706/robot/subsystems/Intake.java
@@ -55,8 +55,8 @@ public class Intake extends Subsystem{
     }
     // Turns the robot motors on to suck in the cube
     public void inhaleCube(double motorSpeed) {
-        left_intake_motor.set(motorSpeed*-1);
-        right_intake_motor.set(motorSpeed*-1); 
+        left_intake_motor.set(motorSpeed*-0.5);
+        right_intake_motor.set(motorSpeed*-0.25); 
     }
     
     // Turns the robot motors on to fire out the cube


### PR DESCRIPTION
Steve did the math, and apparently the "optimal" rotation in RPM on 4"
wheels for 13" cube is about 4:1.  -1/-0.25 works well.  But -0.5/-0.25
works almost just as well.  But turning down the maximum RPM actually works
better for the initial "grabbing" the cube.